### PR TITLE
feat: add OIDC user lookup via database pool

### DIFF
--- a/cmd/projectord/main.go
+++ b/cmd/projectord/main.go
@@ -87,7 +87,7 @@ func run(cfg config) error {
 	serverMux := http.NewServeMux()
 	projectorHttp.New(ctx, projectorHttp.ProjectorConfig{
 		RestricterUrl: cfg.RestricterUrl,
-	}, serverMux, ds, dsFlow)
+	}, serverMux, ds, dsFlow, dsFlow.Pool)
 	fileHandler := http.StripPrefix("/system/projector/static/", http.FileServer(http.Dir("static")))
 	serverMux.Handle("/system/projector/static/", fileHandler)
 

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -15,6 +15,7 @@ import (
 	"github.com/OpenSlides/openslides-go/redis"
 	"github.com/OpenSlides/openslides-projector-service/pkg/database"
 	"github.com/OpenSlides/openslides-projector-service/pkg/projector"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/text/language"
 )
@@ -33,12 +34,12 @@ type projectorHttp struct {
 	auth      *auth.Auth
 }
 
-func New(ctx context.Context, cfg ProjectorConfig, serverMux *http.ServeMux, db *database.Datastore, ds flow.Flow) {
+func New(ctx context.Context, cfg ProjectorConfig, serverMux *http.ServeMux, db *database.Datastore, ds flow.Flow, dbPool *pgxpool.Pool) {
 	projectorPool := projector.NewProjectorPool(ctx, db, ds)
 
 	lookup := new(environment.ForProduction)
 	redis := redis.New(lookup)
-	authService, authBackground, err := auth.New(lookup, redis)
+	authService, authBackground, err := auth.New(lookup, redis, dbPool)
 	if err != nil {
 		log.Err(err).Msg("auth error")
 	}


### PR DESCRIPTION
## Summary

- Pass database pool to auth module for OIDC user lookup by `keycloak_id`

## Test plan

- [ ] Projector service authenticates OIDC users via `keycloak_id`
- [ ] Non-OIDC authentication unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)