### PR TITLE
Add interposed question handling logic in go code and templates

### DIFF
--- a/pkg/projector/slide/current_speaking_structure_level.go
+++ b/pkg/projector/slide/current_speaking_structure_level.go
@@ -42,37 +42,41 @@ func CurrentSpeakingStructureLevelSlideHandler(ctx context.Context, req *project
 	}
 
 	type speakerInfo struct {
-		ID            int
-		Name          string
-		Color         string
-		CountdownTime float64
-		Running       bool
-		Intervention  bool
-		Answer        bool
+		ID                 int
+		Name               string
+		Color              string
+		CountdownTime      float64
+		Running            bool
+		Intervention       bool
+		Answer             bool
+		InterposedQuestion bool
 	}
 
 	var currentSpeakerInfo speakerInfo
 	currentSpeakerInfo.Running = currentSpeaker.PauseTime == 0
+	currentSpeakerInfo.Intervention = currentSpeaker.SpeechState == "intervention"
+	currentSpeakerInfo.InterposedQuestion = currentSpeaker.SpeechState == "interposed_question"
+	currentSpeakerInfo.Answer = currentSpeaker.Answer
 
 	sllos, hasSLLOS := currentSpeaker.StructureLevelListOfSpeakers.Value()
 
-	if currentSpeaker.SpeechState != "intervention" && (!hasSLLOS || sllos.StructureLevelID == 0) {
+	if currentSpeaker.SpeechState != "intervention" &&
+		currentSpeaker.SpeechState != "interposed_question" &&
+		(!hasSLLOS || sllos.StructureLevelID == 0) {
 		return nil, nil
 	}
 
-	if currentSpeaker.SpeechState == "intervention" {
-		currentSpeakerInfo.Intervention = true
-
-		if currentSpeaker.Answer {
-			currentSpeakerInfo.Answer = true
-			currentSpeakerInfo.CountdownTime = viewmodels.Speaker_CalculateElapsedTime(currentSpeaker)
-		} else {
-			defaultInterventionTime, err := req.Fetch.Meeting_ListOfSpeakersInterventionTime(los.MeetingID).Value(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("could not load intervention time: %w", err)
-			}
-			currentSpeakerInfo.CountdownTime = viewmodels.Speaker_CalculateInterventionCountdownTime(currentSpeaker, defaultInterventionTime)
+	if currentSpeaker.SpeechState == "interposed_question" || currentSpeaker.Answer {
+		currentSpeakerInfo.CountdownTime = viewmodels.Speaker_CalculateElapsedTime(currentSpeaker)
+		if hasSLLOS {
+			currentSpeakerInfo.ID = sllos.StructureLevelID
+			currentSpeakerInfo.Color = sllos.StructureLevel.Color
+	} else if currentSpeaker.SpeechState == "intervention" {
+		defaultInterventionTime, err := req.Fetch.Meeting_ListOfSpeakersInterventionTime(los.MeetingID).Value(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("could not load intervention time: %w", err)
 		}
+		currentSpeakerInfo.CountdownTime = viewmodels.Speaker_CalculateInterventionCountdownTime(currentSpeaker, defaultInterventionTime)
 		if hasSLLOS {
 			currentSpeakerInfo.ID = sllos.StructureLevelID
 			currentSpeakerInfo.Color = sllos.StructureLevel.Color

--- a/pkg/projector/slide/current_speaking_structure_level.go
+++ b/pkg/projector/slide/current_speaking_structure_level.go
@@ -71,6 +71,7 @@ func CurrentSpeakingStructureLevelSlideHandler(ctx context.Context, req *project
 		if hasSLLOS {
 			currentSpeakerInfo.ID = sllos.StructureLevelID
 			currentSpeakerInfo.Color = sllos.StructureLevel.Color
+			currentSpeakerInfo.Name = sllos.StructureLevel.Name
 		}
 	} else if currentSpeaker.SpeechState == "intervention" {
 		defaultInterventionTime, err := req.Fetch.Meeting_ListOfSpeakersInterventionTime(los.MeetingID).Value(ctx)

--- a/pkg/projector/slide/current_speaking_structure_level.go
+++ b/pkg/projector/slide/current_speaking_structure_level.go
@@ -71,6 +71,7 @@ func CurrentSpeakingStructureLevelSlideHandler(ctx context.Context, req *project
 		if hasSLLOS {
 			currentSpeakerInfo.ID = sllos.StructureLevelID
 			currentSpeakerInfo.Color = sllos.StructureLevel.Color
+		}
 	} else if currentSpeaker.SpeechState == "intervention" {
 		defaultInterventionTime, err := req.Fetch.Meeting_ListOfSpeakersInterventionTime(los.MeetingID).Value(ctx)
 		if err != nil {

--- a/pkg/projector/slide/current_structure_level_list.go
+++ b/pkg/projector/slide/current_structure_level_list.go
@@ -37,15 +37,14 @@ func CurrentStructureLevelListSlideHandler(ctx context.Context, req *projectionR
 	}
 
 	type structureLevelEntry struct {
-		ID                 int     `json:"id"`
-		Name               string  `json:"name"`
-		Color              string  `json:"color"`
-		SpeechState        string  `json:"speech_state"`
-		CountdownTime      float64 `json:"remaining_time"`
-		Running            bool    `json:"current_start_time"`
-		Intervention       bool
-		Answer             bool
-		InterposedQuestion bool
+		ID            int     `json:"id"`
+		Name          string  `json:"name"`
+		Color         string  `json:"color"`
+		SpeechState   string  `json:"speech_state"`
+		CountdownTime float64 `json:"remaining_time"`
+		Running       bool    `json:"current_start_time"`
+		Intervention  bool
+		Answer        bool
 	}
 	structureLevels := []structureLevelEntry{}
 	for _, sllos := range los.StructureLevelListOfSpeakersList {
@@ -82,24 +81,13 @@ func CurrentStructureLevelListSlideHandler(ctx context.Context, req *projectionR
 
 	var interventionSpeakers []dsmodels.Speaker
 	var answerSpeakers []dsmodels.Speaker
-	var interposedQuestionSpeakers []dsmodels.Speaker
 
 	for _, speaker := range los.SpeakerList {
-		if speaker.EndTime != 0 {
-			continue
-		}
-		switch speaker.SpeechState {
-		case "intervention":
+		if speaker.SpeechState == "intervention" && speaker.EndTime == 0 {
 			if speaker.Answer {
 				answerSpeakers = append(answerSpeakers, speaker)
 			} else {
 				interventionSpeakers = append(interventionSpeakers, speaker)
-			}
-		case "interposed_question":
-			if speaker.Answer {
-				answerSpeakers = append(answerSpeakers, speaker)
-			} else {
-				interposedQuestionSpeakers = append(interposedQuestionSpeakers, speaker)
 			}
 		}
 	}
@@ -138,29 +126,29 @@ func CurrentStructureLevelListSlideHandler(ctx context.Context, req *projectionR
 		structureLevels = append(structureLevels, interventionEntry)
 	}
 
-	for _, speaker := range append(answerSpeakers, interposedQuestionSpeakers...) {
-		isCurrent := viewmodels.Speaker_IsCurrent(&speaker)
-		running := speaker.PauseTime == 0 && isCurrent
+	for _, answerSpeaker := range answerSpeakers {
+		isCurrent := viewmodels.Speaker_IsCurrent(&answerSpeaker)
+		running := answerSpeaker.PauseTime == 0 && isCurrent
 
 		elapsedTime := float64(0)
 		if isCurrent {
-			elapsedTime = viewmodels.Speaker_CalculateElapsedTime(&speaker)
+			elapsedTime = viewmodels.Speaker_CalculateElapsedTime(&answerSpeaker)
 		}
 
-		entry := structureLevelEntry{
-			CountdownTime:      elapsedTime,
-			Running:            running,
-			Intervention:       speaker.SpeechState == "intervention",
-			InterposedQuestion: speaker.SpeechState == "interposed_question",
-			Answer:             speaker.Answer,
+		answerEntry := structureLevelEntry{
+			CountdownTime: elapsedTime,
+			Running:       running,
+			Intervention:  true,
+			Answer:        true,
 		}
 
-		if sllos, ok := speaker.StructureLevelListOfSpeakers.Value(); ok {
-			entry.ID = sllos.StructureLevelID
-			entry.Color = sllos.StructureLevel.Color
+		if answerSpeaker.StructureLevelListOfSpeakers != nil {
+			sllos, ok := answerSpeaker.StructureLevelListOfSpeakers.Value()
+			if ok {
+				answerEntry.ID = sllos.StructureLevelID
+				answerEntry.Color = sllos.StructureLevel.Color
+			}
 		}
-
-		structureLevels = append(structureLevels, entry)
 	}
 
 	titleInfo, err := viewmodels.GetTitleInformationByContentObject(ctx, req.Fetch, los.ContentObjectID)

--- a/pkg/projector/slide/current_structure_level_list.go
+++ b/pkg/projector/slide/current_structure_level_list.go
@@ -149,6 +149,8 @@ func CurrentStructureLevelListSlideHandler(ctx context.Context, req *projectionR
 				answerEntry.Color = sllos.StructureLevel.Color
 			}
 		}
+
+		structureLevels = append(structureLevels, answerEntry)
 	}
 
 	titleInfo, err := viewmodels.GetTitleInformationByContentObject(ctx, req.Fetch, los.ContentObjectID)

--- a/pkg/projector/slide/current_structure_level_list.go
+++ b/pkg/projector/slide/current_structure_level_list.go
@@ -37,14 +37,15 @@ func CurrentStructureLevelListSlideHandler(ctx context.Context, req *projectionR
 	}
 
 	type structureLevelEntry struct {
-		ID            int     `json:"id"`
-		Name          string  `json:"name"`
-		Color         string  `json:"color"`
-		SpeechState   string  `json:"speech_state"`
-		CountdownTime float64 `json:"remaining_time"`
-		Running       bool    `json:"current_start_time"`
-		Intervention  bool
-		Answer        bool
+		ID                 int     `json:"id"`
+		Name               string  `json:"name"`
+		Color              string  `json:"color"`
+		SpeechState        string  `json:"speech_state"`
+		CountdownTime      float64 `json:"remaining_time"`
+		Running            bool    `json:"current_start_time"`
+		Intervention       bool
+		Answer             bool
+		InterposedQuestion bool
 	}
 	structureLevels := []structureLevelEntry{}
 	for _, sllos := range los.StructureLevelListOfSpeakersList {
@@ -81,13 +82,24 @@ func CurrentStructureLevelListSlideHandler(ctx context.Context, req *projectionR
 
 	var interventionSpeakers []dsmodels.Speaker
 	var answerSpeakers []dsmodels.Speaker
+	var interposedQuestionSpeakers []dsmodels.Speaker
 
 	for _, speaker := range los.SpeakerList {
-		if speaker.SpeechState == "intervention" && speaker.EndTime == 0 {
+		if speaker.EndTime != 0 {
+			continue
+		}
+		switch speaker.SpeechState {
+		case "intervention":
 			if speaker.Answer {
 				answerSpeakers = append(answerSpeakers, speaker)
 			} else {
 				interventionSpeakers = append(interventionSpeakers, speaker)
+			}
+		case "interposed_question":
+			if speaker.Answer {
+				answerSpeakers = append(answerSpeakers, speaker)
+			} else {
+				interposedQuestionSpeakers = append(interposedQuestionSpeakers, speaker)
 			}
 		}
 	}
@@ -126,31 +138,29 @@ func CurrentStructureLevelListSlideHandler(ctx context.Context, req *projectionR
 		structureLevels = append(structureLevels, interventionEntry)
 	}
 
-	for _, answerSpeaker := range answerSpeakers {
-		isCurrent := viewmodels.Speaker_IsCurrent(&answerSpeaker)
-		running := answerSpeaker.PauseTime == 0 && isCurrent
+	for _, speaker := range append(answerSpeakers, interposedQuestionSpeakers...) {
+		isCurrent := viewmodels.Speaker_IsCurrent(&speaker)
+		running := speaker.PauseTime == 0 && isCurrent
 
 		elapsedTime := float64(0)
 		if isCurrent {
-			elapsedTime = viewmodels.Speaker_CalculateElapsedTime(&answerSpeaker)
+			elapsedTime = viewmodels.Speaker_CalculateElapsedTime(&speaker)
 		}
 
-		answerEntry := structureLevelEntry{
-			CountdownTime: elapsedTime,
-			Running:       running,
-			Intervention:  true,
-			Answer:        true,
+		entry := structureLevelEntry{
+			CountdownTime:      elapsedTime,
+			Running:            running,
+			Intervention:       speaker.SpeechState == "intervention",
+			InterposedQuestion: speaker.SpeechState == "interposed_question",
+			Answer:             speaker.Answer,
 		}
 
-		if answerSpeaker.StructureLevelListOfSpeakers != nil {
-			sllos, ok := answerSpeaker.StructureLevelListOfSpeakers.Value()
-			if ok {
-				answerEntry.ID = sllos.StructureLevelID
-				answerEntry.Color = sllos.StructureLevel.Color
-			}
+		if sllos, ok := speaker.StructureLevelListOfSpeakers.Value(); ok {
+			entry.ID = sllos.StructureLevelID
+			entry.Color = sllos.StructureLevel.Color
 		}
 
-		structureLevels = append(structureLevels, answerEntry)
+		structureLevels = append(structureLevels, entry)
 	}
 
 	titleInfo, err := viewmodels.GetTitleInformationByContentObject(ctx, req.Fetch, los.ContentObjectID)

--- a/templates/slides/current_speaking_structure_level.html
+++ b/templates/slides/current_speaking_structure_level.html
@@ -3,7 +3,6 @@
   type="text/css"
   href="/system/projector/static/slide/projector_current_speaking_structure_level.css"
 />
-<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
 
 <div class="content current-speaking-structure-level overlay">
   {{ with .SpeakerInfo }}
@@ -31,22 +30,22 @@
         {{ end }}
         {{ if and .Answer .Intervention }}
           <div class="intervention">
-            <i class="material-icons">feedback</i>
+            <span class="material-icons">feedback</span>
             {{- Loc.Get "Answer to intervention" -}}
           </div>
         {{ else if and .Answer .InterposedQuestion }}
           <div class="intervention">
-            <i class="material-icons">contact_support</i>
+            <span class="material-icons">contact_support</span>
             {{- Loc.Get "Answer to interposed question" -}}
           </div>
         {{ else if .Intervention }}
           <div class="intervention">
-            <i class="material-icons">feedback</i>
+            <span class="material-icons">feedback</span>
             {{- Loc.Get "Intervention" -}}
           </div>
         {{ else if .InterposedQuestion }}
           <div class="intervention">
-            <i class="material-icons">contact_support</i>
+            <span class="material-icons">contact_support</span>
             {{- Loc.Get "Interposed question" -}}
           </div>
         {{ end }}

--- a/templates/slides/current_speaking_structure_level.html
+++ b/templates/slides/current_speaking_structure_level.html
@@ -3,6 +3,7 @@
   type="text/css"
   href="/system/projector/static/slide/projector_current_speaking_structure_level.css"
 />
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 
 <div class="content current-speaking-structure-level overlay">
   {{ with .SpeakerInfo }}
@@ -30,19 +31,23 @@
         {{ end }}
         {{ if and .Answer .Intervention }}
           <div class="intervention">
-            {{ Loc.Get "Answer to intervention" }}
+            <i class="material-icons">feedback</i>
+            {{- Loc.Get "Answer to intervention" -}}
           </div>
         {{ else if and .Answer .InterposedQuestion }}
           <div class="intervention">
-            {{ Loc.Get "Answer to interposed question" }}
+            <i class="material-icons">contact_support</i>
+            {{- Loc.Get "Answer to interposed question" -}}
           </div>
         {{ else if .Intervention }}
           <div class="intervention">
-            {{ Loc.Get "Intervention" }}
+            <i class="material-icons">feedback</i>
+            {{- Loc.Get "Intervention" -}}
           </div>
         {{ else if .InterposedQuestion }}
           <div class="intervention">
-            {{ Loc.Get "Interposed question" }}
+            <i class="material-icons">contact_support</i>
+            {{- Loc.Get "Interposed question" -}}
           </div>
         {{ end }}
       </div>

--- a/templates/slides/current_speaking_structure_level.html
+++ b/templates/slides/current_speaking_structure_level.html
@@ -19,6 +19,7 @@
           countdown-time="{{ printf "%.0f" .CountdownTime }}"
           running="{{ .Running }}"
           {{ if and .Answer .Running }}default-time="0"{{ end }}
+          {{ if and .InterposedQuestion .Running }}default-time="0"{{ end }}
         ></projector-countdown>
       </div>
       <div class="structure-level-name">
@@ -27,16 +28,22 @@
             {{ .Name }}
           </div>
         {{ end }}
-        {{ if .Intervention }}
-          {{ if .Answer }}
-            <div class="intervention">
-              {{ Loc.Get "Answer to intervention" }}
-            </div>
-          {{ else }}
-            <div class="intervention">
-              {{ Loc.Get "Intervention" }}
-            </div>
-          {{ end }}
+        {{ if and .Answer .Intervention }}
+          <div class="intervention">
+            {{ Loc.Get "Answer to intervention" }}
+          </div>
+        {{ else if and .Answer .InterposedQuestion }}
+          <div class="intervention">
+            {{ Loc.Get "Answer to interposed question" }}
+          </div>
+        {{ else if .Intervention }}
+          <div class="intervention">
+            {{ Loc.Get "Intervention" }}
+          </div>
+        {{ else if .InterposedQuestion }}
+          <div class="intervention">
+            {{ Loc.Get "Interposed question" }}
+          </div>
         {{ end }}
       </div>
     </div>

--- a/templates/slides/current_speaking_structure_level.html
+++ b/templates/slides/current_speaking_structure_level.html
@@ -3,7 +3,7 @@
   type="text/css"
   href="/system/projector/static/slide/projector_current_speaking_structure_level.css"
 />
-<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
 
 <div class="content current-speaking-structure-level overlay">
   {{ with .SpeakerInfo }}

--- a/templates/slides/current_structure_level_list.html
+++ b/templates/slides/current_structure_level_list.html
@@ -37,7 +37,6 @@
             countdown-time="{{ printf "%.0f" .CountdownTime }}"
             running="{{ .Running }}"
             {{ if and .Answer .Running }}default-time="0"{{ end }}
-            {{ if and .InterposedQuestion .Running }}default-time="0"{{ end }}
           ></projector-countdown>
         </div>
         <div class="structure-level-name">
@@ -50,17 +49,9 @@
             <div class="intervention">
               {{ Loc.Get "Answer to intervention" }}
             </div>
-          {{ else if and .Answer .InterposedQuestion }}
-            <div class="intervention">
-              {{ Loc.Get "Answer to interposed question" }}
-            </div>
           {{ else if .Intervention }}
             <div class="intervention">
               {{ Loc.Get "Intervention" }}
-            </div>
-          {{ else if .InterposedQuestion }}
-            <div class="intervention">
-              {{ Loc.Get "Interposed question" }}
             </div>
           {{ end }}
         </div>

--- a/templates/slides/current_structure_level_list.html
+++ b/templates/slides/current_structure_level_list.html
@@ -37,6 +37,7 @@
             countdown-time="{{ printf "%.0f" .CountdownTime }}"
             running="{{ .Running }}"
             {{ if and .Answer .Running }}default-time="0"{{ end }}
+            {{ if and .InterposedQuestion .Running }}default-time="0"{{ end }}
           ></projector-countdown>
         </div>
         <div class="structure-level-name">
@@ -45,16 +46,22 @@
               {{ .Name }}
             </div>
           {{ end }}
-          {{ if .Intervention }}
-            {{ if .Answer }}
-              <div class="intervention">
-                {{ Loc.Get "Answer to intervention" }}
-              </div>
-            {{ else }}
-              <div class="intervention">
-                {{ Loc.Get "Intervention" }}
-              </div>
-            {{ end }}
+          {{ if and .Answer .Intervention }}
+            <div class="intervention">
+              {{ Loc.Get "Answer to intervention" }}
+            </div>
+          {{ else if and .Answer .InterposedQuestion }}
+            <div class="intervention">
+              {{ Loc.Get "Answer to interposed question" }}
+            </div>
+          {{ else if .Intervention }}
+            <div class="intervention">
+              {{ Loc.Get "Intervention" }}
+            </div>
+          {{ else if .InterposedQuestion }}
+            <div class="intervention">
+              {{ Loc.Get "Interposed question" }}
+            </div>
           {{ end }}
         </div>
       </div>

--- a/web/src/slide/projector_current_speaking_structure_level.css
+++ b/web/src/slide/projector_current_speaking_structure_level.css
@@ -44,9 +44,9 @@
       word-wrap: break-word;
     }
     .intervention .material-icons {
-        font-size: 1em;
-        vertical-align: middle;
-        justify-content: end;
+      font-size: 1em;
+      vertical-align: middle;
+      justify-content: end;
     }
   }
 

--- a/web/src/slide/projector_current_speaking_structure_level.css
+++ b/web/src/slide/projector_current_speaking_structure_level.css
@@ -3,7 +3,7 @@
 
   .current-speaking-structure-level-countdown {
     position: absolute;
-    top: calc(max(402px, 50%) - 250px);
+    top: calc(max(402px, 50%) - 285px);
     right: 0;
     z-index: 10;
     text-align: right;
@@ -36,12 +36,17 @@
 
   .structure-level-name {
     text-align: right;
-    font-size: 70px;
-    line-height: 70px;
+    font-size: 60px;
+    line-height: 60px;
 
     .intervention {
       white-space: normal;
       word-wrap: break-word;
+    }
+    .intervention .material-icons {
+        font-size: 1em;
+        vertical-align: middle;
+        justify-content: end;
     }
   }
 


### PR DESCRIPTION
resolves #318 

The interposed questions (and answers) weren't handled seperately in the current_speaker_structure_level.go and current_speaker_structure_level_list.go and their respective templates. This should fix it.

Since these functions are not available in the demo.openslides.org autopilot structure level view, I had to make some guesses on what is required (like adding structure level color to interposed question and answer, if speaker with structure level selected)