### PR TITLE
adjust intervention countdown timer calculation to only use speaker times

### DIFF
--- a/pkg/viewmodels/speaker.go
+++ b/pkg/viewmodels/speaker.go
@@ -34,9 +34,9 @@ func Speaker_CalculateInterventionCountdownTime(speaker *dsmodels.Speaker, inter
 	}
 
 	if speaker.PauseTime == 0 {
-		return float64(interventionTime) + Speaker_CalculateElapsedTime(&speaker)
+		return float64(interventionTime) + Speaker_CalculateElapsedTime(speaker)
 	} else {
-		return float64(interventionTime) - Speaker_CalculateElapsedTime(&speaker)
+		return float64(interventionTime) - Speaker_CalculateElapsedTime(speaker)
 	}
 }
 

--- a/pkg/viewmodels/speaker.go
+++ b/pkg/viewmodels/speaker.go
@@ -34,9 +34,9 @@ func Speaker_CalculateInterventionCountdownTime(speaker *dsmodels.Speaker, inter
 	}
 
 	if speaker.PauseTime == 0 {
-		return float64(speaker.BeginTime) + float64(interventionTime) + float64(speaker.TotalPause)
+		return float64(interventionTime) + Speaker_CalculateElapsedTime(&speaker)
 	} else {
-		return float64(speaker.BeginTime) + float64(interventionTime) + float64(speaker.TotalPause) - float64(speaker.PauseTime)
+		return float64(interventionTime) - Speaker_CalculateElapsedTime(&speaker)
 	}
 }
 

--- a/pkg/viewmodels/speaker.go
+++ b/pkg/viewmodels/speaker.go
@@ -2,7 +2,6 @@ package viewmodels
 
 import (
 	"context"
-	"time"
 
 	"github.com/OpenSlides/openslides-go/datastore/dsmodels"
 )
@@ -37,9 +36,7 @@ func Speaker_CalculateInterventionCountdownTime(speaker *dsmodels.Speaker, inter
 	if speaker.PauseTime == 0 {
 		return float64(speaker.BeginTime) + float64(interventionTime) + float64(speaker.TotalPause)
 	} else {
-		now := int(time.Now().Unix())
-		elapsed := now - speaker.BeginTime - speaker.TotalPause
-		return float64(interventionTime) - float64(elapsed)
+		return float64(speaker.BeginTime) + float64(interventionTime) + float64(speaker.TotalPause) - float64(speaker.PauseTime)
 	}
 }
 


### PR DESCRIPTION
partially resolves #317 

This fix adjusts the intervention countdown timer calculation to only use speaker model time fields. This might help with some of the time discrepancy, but might be insufficient in regards to the different ways projector and client calculate their time values, as @bastianjoel mentioned in said issue.