### PR TITLE
Fix/live poll published

### DIFF
--- a/pkg/viewmodels/content_object.go
+++ b/pkg/viewmodels/content_object.go
@@ -52,7 +52,7 @@ func GetTitleInformationByContentObject(ctx context.Context, fetch *dsmodels.Fet
 
 	// AgendaItemNumber
 	switch result.Collection {
-	case "assignemnt", "topic", "motion", "motion_block":
+	case "assignment", "topic", "motion", "motion_block":
 		agendaItemID, err := GetContentObjectField[int](ctx, fetch, "agenda_item_id", fqid)
 		if err != nil {
 			return TitleInformation{}, fmt.Errorf("could not fetch agenda item id: %w", err)

--- a/pkg/viewmodels/content_object.go
+++ b/pkg/viewmodels/content_object.go
@@ -113,6 +113,8 @@ func GetTitleInformationByContentObject(ctx context.Context, fetch *dsmodels.Fet
 		}
 
 		result.Title = strings.Trim(fullName, " ")
+	case "poll_candidate_list":
+		result.Title = ""
 	default:
 		title, err := GetContentObjectField[string](ctx, fetch, "title", fqid)
 		if err != nil {


### PR DESCRIPTION
partially resolves #351 

@bastianjoel this fix is not an optimal solution. There was an error when trying to get the collection title for the "poll_candidate_list" collection. Since we use switch/case/default pattern in the viewmodels.GetTitleInformationByContentObject and the "poll_candidate_list" collection was not treated separately, it ran into the default that tries to construct a dskey.FromStringF with a field unavailable for that particular collection. It should be evaluated, whether there's more collections we could run into errors with when falling through to the default case. 

PS: also fixed a small typo in result.Collection switch