### PR TITLE
Debounce flushing server sent events

### DIFF
--- a/pkg/http/handler_projector_subscribe.go
+++ b/pkg/http/handler_projector_subscribe.go
@@ -93,6 +93,7 @@ func (s *projectorHttp) ProjectorSubscribeHandler() http.HandlerFunc {
 					log.Err(err).Msg("error sending event")
 				}
 
+				// Debounce sending events
 				if flushTimer == nil {
 					flushTimer = time.NewTimer(50 * time.Millisecond)
 					flushC = flushTimer.C

--- a/pkg/http/handler_projector_subscribe.go
+++ b/pkg/http/handler_projector_subscribe.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -67,6 +68,22 @@ func (s *projectorHttp) ProjectorSubscribeHandler() http.HandlerFunc {
 			return
 		}
 
+		var flushTimer *time.Timer
+		var flushC <-chan time.Time
+
+		defer func() {
+			if flushTimer != nil {
+				flushTimer.Stop()
+			}
+
+			f, ok := w.(http.Flusher)
+			if !ok {
+				log.Warn().Msg("connection lost or flusher unavailable, stopping stream")
+				return
+			}
+			f.Flush()
+		}()
+
 		for {
 			select {
 			case <-r.Context().Done():
@@ -76,12 +93,20 @@ func (s *projectorHttp) ProjectorSubscribeHandler() http.HandlerFunc {
 					log.Err(err).Msg("error sending event")
 				}
 
+				if flushTimer == nil {
+					flushTimer = time.NewTimer(50 * time.Millisecond)
+					flushC = flushTimer.C
+				}
+			case <-flushC:
 				f, ok := w.(http.Flusher)
 				if !ok {
 					log.Warn().Msg("connection lost or flusher unavailable, stopping stream")
 					return
 				}
 				f.Flush()
+
+				flushTimer = nil
+				flushC = nil
 			}
 		}
 	}

--- a/web/src/projector.js
+++ b/web/src/projector.js
@@ -103,10 +103,12 @@ export function Projector(host, id, auth = () => ``, config = {}) {
         projectorContainer.style.setProperty(prop, cssProperties[prop]);
       }
     }
+
+    console.debug(`[projector]`, `settings updated`, [e.data]);
   });
 
   eventSource.addEventListener(`deleted`, () => {
-    console.debug(`deleted`);
+    console.debug(`[projector]`, `deleted ${id}`);
   });
 
   eventSource.addEventListener(`connected`, e => {
@@ -116,10 +118,12 @@ export function Projector(host, id, auth = () => ``, config = {}) {
     };
     clock.update();
 
-    console.debug(`connected`);
+    console.debug(`[projector]`, `connected ${id}`);
   });
 
   eventSource.addEventListener(`projector-replace`, e => {
+    console.debug(`[projector]`, `projector-replace`, [e.data]);
+
     const html = JSON.parse(e.data);
     container.innerHTML = html;
 
@@ -129,6 +133,8 @@ export function Projector(host, id, auth = () => ``, config = {}) {
   });
 
   eventSource.addEventListener(`projection-updated`, e => {
+    console.debug(`[projector]`, `projection-updated`, [e.data]);
+
     const data = JSON.parse(e.data);
 
     for (let id of Object.keys(data)) {
@@ -149,7 +155,7 @@ export function Projector(host, id, auth = () => ``, config = {}) {
   });
 
   eventSource.addEventListener(`projection-deleted`, e => {
-    console.debug(`projection-deleted`, e.data);
+    console.debug(`[projector]`, `projection-deleted`, e.data);
 
     container.querySelector(`#slides > [data-id="${e.data}"]`)?.remove();
     container.querySelector(`.overlay-container > [data-id="${e.data}"]`)?.remove();


### PR DESCRIPTION
This is a workaround for apple devices. 

With the recent webkit update it seems like that when server sent events are sent too fast after each other there is a chance that messages are dropped. 
This is reliably reproducible on iOS devices with recent webkit. 

While at the current stage I consider this a workaround it might be a good idea to implement something like this in a more sophisticated way with the ability to drop redundant messages. E.g. when sending a `projector-replace` event all other messages in queue can be dropped. 

resolves #435