### PR TITLE
Fix potential panic on projection subscription remove

### DIFF
--- a/pkg/projector/slide/slide.go
+++ b/pkg/projector/slide/slide.go
@@ -82,8 +82,10 @@ func (r *SlideRouter) SubscribeContent(addProjection <-chan int, removeProjectio
 					go r.subscribeProjection(ctx, id, updateChannel)
 				}
 			case id := <-removeProjection:
-				contextCancel[id]()
-				delete(contextCancel, id)
+				if cancel, ok := contextCancel[id]; ok {
+					cancel()
+					delete(contextCancel, id)
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
I was able to observe this behavior when changing a projection after the previous projection produced an error. However - on many attempts I was only able to reproduce this once. 